### PR TITLE
My solution

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,2 @@
+continue
+last_response

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in rack-monitor.gemspec
 gemspec
+gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
     daemons (1.4.0)
     eventmachine (1.2.7)
     minitest (5.14.4)
@@ -25,6 +26,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.2.3)
+  byebug
   minitest (~> 5.0)
   rack-monitor!
   rack-test (~> 1.1.0)

--- a/bin/server
+++ b/bin/server
@@ -5,7 +5,7 @@ require "rack/monitor"
 require "thin"
 
 app = Rack::Builder.new do |builder|
-  builder.use Rack::Monitor
+  builder.use Rack::Monitor, "exceptions.log"
   builder.run lambda { |env| [200, {}, ["Welcome!"]]}
 end.to_app
   

--- a/lib/rack/monitor.rb
+++ b/lib/rack/monitor.rb
@@ -3,13 +3,31 @@ require "rack"
 module Rack
   class Monitor
     class Error < StandardError; end
-    # Your code goes here...
-    def initialize(app)
+    def initialize(app, log_path)
       @app = app
+      @log_path = log_path
     end
 
     def call(env)
-      
+      request_method = env["REQUEST_METHOD"]
+      if request_method == "GET"
+         return get(env)
+      end
+      @app.call(env)
+    end
+
+    def get(env)
+      case env["PATH_INFO"]
+      when "/_ping"
+       return [200, {}, ["PONG"]]
+      when "/_boom"
+       ::File.open(@log_path, "a+") do |line|
+         line << "#{Time.now}\n"
+       end
+       return [500, {}, ["BOOM"]]
+      else
+        @app.call(env)
+      end
     end
   end
 end

--- a/test/rack/monitor_test.rb
+++ b/test/rack/monitor_test.rb
@@ -1,30 +1,31 @@
 require "test_helper"
+require "byebug"
 
 class Rack::MonitorTest < Minitest::Test
   include Rack::Test::Methods
 
   def exception_log
-    File.open("exceptions.log", "a+")
+    ::File.open("exceptions.log", "a+")
   end
 
   def exception_log_length
     file = exception_log
-    length = file.read.length
+    length = file.readlines.length
     file.close
     length
   end
 
   def app
-    builder = Rack::Builder.new
-    builder.use Rack::Monitor
-    builder.run lambda { |env| [200, {}, ["Welcome!"]]}
+    Rack::Builder.new do |builder|
+      builder.use Rack::Monitor, "exceptions.log"
+      builder.run lambda { |env| [200, {}, ["Welcome!"]]}
+    end.to_app
   end
 
   def test_ping_responds_pong
     get "/_ping"
-
     assert last_response.ok?
-    assert_equal last_response.body, "PONG"
+    assert_equal "PONG", last_response.body
   end
 
   def test_boom_responds_500
@@ -42,6 +43,13 @@ class Rack::MonitorTest < Minitest::Test
 
   def test_passes_through_requests
     get "/foo"
+    
+    assert last_response.ok?
+    assert_equal "Welcome!", last_response.body
+  end
+
+  def test_post_request_passes_through
+    post "/foo"
     
     assert last_response.ok?
     assert_equal "Welcome!", last_response.body


### PR DESCRIPTION
The Monitor class gets the log file name and deals with determining what path was sent to the middleware (assumes only `get` request sent as no other request is needed but can be expanded in the `call` method).  The `call` method takes care of routing the request (in this case just `get`) to the appropriate helper (routing) method, passing along the environment variable. The `get` method determines the path sent within the `env` variable and decides whether the path is `/_ping` or `/_boom`. According to the exercise instructions, if  `/_ping` the method returns a 200 status, no header (not needed) and simply "PONG" as the response body. If `/_boom` the method logs the current time stamp in the file specified in the initialize method in append mode. Then returns a 500 status code, no header, and simply "BOOM" as the response body (this simulates logging when a server error has occurred and logs it locally). If neither of those paths are sent, simply pass the `env` along to the app.